### PR TITLE
Make lint settings apply to the correct object.

### DIFF
--- a/src/hyperloglog/lib.rs
+++ b/src/hyperloglog/lib.rs
@@ -11,7 +11,7 @@
 #[warn(non_camel_case_types,
        non_uppercase_statics,
        unnecessary_qualification,
-       managed_heap_memory)]
+       managed_heap_memory)];
 
 extern mod extra;
 


### PR DESCRIPTION
They were attached to the `extern mod extra` previously and so were having no effect.

(Unfortunately I can only do this via the github web interface at the moment and so can't test/fix any new warnings this change creates.)
