### PR TITLE
feat: impl codec

### DIFF
--- a/src/hyperloglog/lib.rs
+++ b/src/hyperloglog/lib.rs
@@ -4018,6 +4018,22 @@ impl HyperLogLog {
         }
     }
 
+    pub fn new_with_keys(error_rate: f64, key0: u64, key1: u64) -> Self {
+        assert!(error_rate > 0.0 && error_rate < 1.0);
+        let sr = 1.04 / error_rate;
+        let p = f64::ln(sr * sr).ceil() as u8;
+        assert!(p <= 64);
+        let alpha = Self::get_alpha(p);
+        let m = 1usize << p;
+        HyperLogLog {
+            alpha,
+            p,
+            m,
+            M: repeat(0u8).take(m).collect(),
+            sip: SipHasher13::new_with_keys(key0, key1),
+        }
+    }
+
     pub fn insert<V: Hash>(&mut self, value: &V) {
         let sip = &mut self.sip.clone();
         value.hash(sip);

--- a/src/hyperloglog/lib.rs
+++ b/src/hyperloglog/lib.rs
@@ -4018,13 +4018,17 @@ impl HyperLogLog {
         }
     }
 
-    pub fn new_with_keys(error_rate: f64, key0: u64, key1: u64) -> Self {
+    pub fn new_with_key(error_rate: f64, key: u128) -> Self {
         assert!(error_rate > 0.0 && error_rate < 1.0);
         let sr = 1.04 / error_rate;
         let p = f64::ln(sr * sr).ceil() as u8;
         assert!(p <= 64);
         let alpha = Self::get_alpha(p);
         let m = 1usize << p;
+
+        let key0 = (key >> 64) as u64;
+        let key1 = (key & u64::MAX as u128) as u64;
+
         HyperLogLog {
             alpha,
             p,


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>
Co-authored-by: evenyag <realevenyag@gmail.com>

Thanks for your brilliant work!

This PR add two method to support serialization.
```rust
pub fn write_to_buf(&self, buf: &mut impl Write) -> Result<(), std::io::Error>;
pub fn read_from_buf(buf: &mut impl Read) -> Result<Self, std::io::Error>;
```