### PR TITLE
Added mem-dbg as optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bytecount = "0.6"
 rand = "0.8.0"
 serde = { version = "1.0", optional = true }
 siphasher = "0.3"
+mem_dbg = {version = "0.2.2", optional = true}
 
 [dev-dependencies]
 bincode = "1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use siphasher::sip::SipHasher13;
 /// A HyperLogLog counter
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemDbg, mem_dbg::MemSize))]
 pub struct HyperLogLog {
     alpha: f64,
     p: u8,


### PR DESCRIPTION
[Mem-dbg](https://crates.io/crates/mem_dbg) is a crate that allows to compute the size of a struct. I have added the derives through the crate as an optional feature, so as to use it to compare this implementation with others easily.

Cheers!